### PR TITLE
Fix chalk demo and enable tests

### DIFF
--- a/nodeBasics/index.js
+++ b/nodeBasics/index.js
@@ -1,3 +1,0 @@
-import chalk from 'chalk';
-
-console.log(chalk.blue('Hello world!'));

--- a/nodeBasics/index.mjs
+++ b/nodeBasics/index.mjs
@@ -1,0 +1,4 @@
+import chalk from 'chalk';
+
+console.log(chalk.blue('Hello world!'));
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- use `.mjs` extension for chalk demo
- run `jest` via npm test

## Testing
- `node nodeBasics/index.mjs`
- `npm test` *(fails: jest not found)*